### PR TITLE
More notifications: email on team add + notification preferences

### DIFF
--- a/.claude/prompts/0039-more-notifications.md
+++ b/.claude/prompts/0039-more-notifications.md
@@ -1,0 +1,23 @@
+Let's resolve issue #39 with more notifications.
+
+Currently, I can add a user as a coach or a performer on a team and it will send an email to create an account. If I 
+add an existing user, it will put the request in their approval queue but requires the user to check. Let's add 
+ email templates that will notify the user in those situations.
+
+Let's also update the "My Profile" section with a "Notifications" section where users can turn on or off email or 
+desktop notifications for all the places we send notifications:
+- Monthly freshness check (show this but don't allow users to disable)
+- Someone adds me as a performer 
+- Someone adds me as a coach
+
+Can you..
+- confirm these scenaros
+- propose copy consistent with our tone and vibe
+
+Let's also as part of this add support for desktop notifications if it's not too much work.
+
+For this feature:
+- Let's plan out a series of atomic commits with conventional commit messages
+- Once the feature is built, let's verify in the browser
+- Once it is built and verified, create a draft PR via the github CLI and make a PR description summarizing the change
+- Let me manually confirm the changes and merge the PR

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ build/
 .env
 .env.local
 .env.*.local
+*.env
 
 # Local PGLite database — developer-specific, do not commit
 .local-db/

--- a/src/lib/server/db/migrations/0002_jittery_bastion.sql
+++ b/src/lib/server/db/migrations/0002_jittery_bastion.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN "notification_preferences" jsonb DEFAULT '{}'::jsonb NOT NULL;

--- a/src/lib/server/db/migrations/meta/0002_snapshot.json
+++ b/src/lib/server/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,1217 @@
+{
+  "id": "e9bc3639-6ddd-42c1-9fbf-e7d187e5ec2e",
+  "prevId": "70d50668-2fd5-4b5f-81a0-38e8660b58e6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.coach_profiles": {
+      "name": "coach_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coaching_bio": {
+          "name": "coaching_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available_for_private": {
+          "name": "available_for_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "available_for_teams": {
+          "name": "available_for_teams",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "available_for_practice_group": {
+          "name": "available_for_practice_group",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coach_profiles_profile_id_personal_profiles_id_fk": {
+          "name": "coach_profiles_profile_id_personal_profiles_id_fk",
+          "tableFrom": "coach_profiles",
+          "tableTo": "personal_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "coach_profiles_profile_id_unique": {
+          "name": "coach_profiles_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_messages": {
+      "name": "contact_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "recipient_type": {
+          "name": "recipient_type",
+          "type": "recipient_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_user_id": {
+          "name": "sender_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contact_messages_sender_user_id_users_id_fk": {
+          "name": "contact_messages_sender_user_id_users_id_fk",
+          "tableFrom": "contact_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sender_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_tags": {
+      "name": "entity_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "tag_domain",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by_user_id": {
+          "name": "added_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "entity_tags_tag_id_tags_id_fk": {
+          "name": "entity_tags_tag_id_tags_id_fk",
+          "tableFrom": "entity_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_tags_added_by_user_id_users_id_fk": {
+          "name": "entity_tags_added_by_user_id_users_id_fk",
+          "tableFrom": "entity_tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entity_tags_tag_entity_unique": {
+          "name": "entity_tags_tag_entity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tag_id",
+            "entity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identity_id": {
+          "name": "identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'email'"
+        },
+        "admin": {
+          "name": "admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_preferences": {
+          "name": "notification_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_identity_id_unique": {
+          "name": "users_identity_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_profiles": {
+      "name": "personal_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "training": {
+          "name": "training",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "looking_for": {
+          "name": "looking_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "personal_profiles_user_id_users_id_fk": {
+          "name": "personal_profiles_user_id_users_id_fk",
+          "tableFrom": "personal_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_profiles_user_id_unique": {
+          "name": "personal_profiles_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "personal_profiles_slug_unique": {
+          "name": "personal_profiles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.performer_profiles": {
+      "name": "performer_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "video_highlights": {
+          "name": "video_highlights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "looking_for_practice_group": {
+          "name": "looking_for_practice_group",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "looking_for_small_group": {
+          "name": "looking_for_small_group",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "looking_for_indie_team": {
+          "name": "looking_for_indie_team",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "looking_for": {
+          "name": "looking_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "performer_profiles_profile_id_personal_profiles_id_fk": {
+          "name": "performer_profiles_profile_id_personal_profiles_id_fk",
+          "tableFrom": "performer_profiles",
+          "tableTo": "personal_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "performer_profiles_profile_id_unique": {
+          "name": "performer_profiles_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "team_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stub'"
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form": {
+          "name": "form",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_practice_group": {
+          "name": "is_practice_group",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "open_to_new_members": {
+          "name": "open_to_new_members",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "open_to_book_openers": {
+          "name": "open_to_book_openers",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "seeking_coach": {
+          "name": "seeking_coach",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "looking_for": {
+          "name": "looking_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_contact_profile_id": {
+          "name": "primary_contact_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_created_by_user_id_users_id_fk": {
+          "name": "teams_created_by_user_id_users_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "teams_primary_contact_profile_id_personal_profiles_id_fk": {
+          "name": "teams_primary_contact_profile_id_personal_profiles_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "personal_profiles",
+          "columnsFrom": [
+            "primary_contact_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_slug_unique": {
+          "name": "teams_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_name": {
+          "name": "member_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_email": {
+          "name": "invite_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_token": {
+          "name": "invite_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_year": {
+          "name": "start_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_month": {
+          "name": "start_month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_year": {
+          "name": "end_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_month": {
+          "name": "end_month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_current": {
+          "name": "is_current",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "approval_status": {
+          "name": "approval_status",
+          "type": "approval_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_profile_id_personal_profiles_id_fk": {
+          "name": "team_members_profile_id_personal_profiles_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "personal_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_coaches": {
+      "name": "team_coaches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coach_name": {
+          "name": "coach_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_email": {
+          "name": "invite_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_token": {
+          "name": "invite_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_year": {
+          "name": "start_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_month": {
+          "name": "start_month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_year": {
+          "name": "end_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_month": {
+          "name": "end_month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_current": {
+          "name": "is_current",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "approval_status": {
+          "name": "approval_status",
+          "type": "approval_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_coaches_team_id_teams_id_fk": {
+          "name": "team_coaches_team_id_teams_id_fk",
+          "tableFrom": "team_coaches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_coaches_profile_id_personal_profiles_id_fk": {
+          "name": "team_coaches_profile_id_personal_profiles_id_fk",
+          "tableFrom": "team_coaches",
+          "tableTo": "personal_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "tag_domain",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tag_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "suggested_by_user_id": {
+          "name": "suggested_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_on_entity_id": {
+          "name": "suggested_on_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tags_suggested_by_user_id_users_id_fk": {
+          "name": "tags_suggested_by_user_id_users_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "suggested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_domain_unique": {
+          "name": "tags_name_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reactions": {
+      "name": "reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "reaction_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction_type": {
+          "name": "reaction_type",
+          "type": "reaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reactions_user_id_users_id_fk": {
+          "name": "reactions_user_id_users_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reactions_entity_type_user_unique": {
+          "name": "reactions_entity_type_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entity_id",
+            "reaction_type",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.recipient_type": {
+      "name": "recipient_type",
+      "schema": "public",
+      "values": [
+        "personal_profile",
+        "team"
+      ]
+    },
+    "public.team_status": {
+      "name": "team_status",
+      "schema": "public",
+      "values": [
+        "stub",
+        "active"
+      ]
+    },
+    "public.approval_status": {
+      "name": "approval_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.tag_domain": {
+      "name": "tag_domain",
+      "schema": "public",
+      "values": [
+        "performer",
+        "coach",
+        "team"
+      ]
+    },
+    "public.tag_status": {
+      "name": "tag_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.reaction_entity_type": {
+      "name": "reaction_entity_type",
+      "schema": "public",
+      "values": [
+        "performer",
+        "coach",
+        "team"
+      ]
+    },
+    "public.reaction_type": {
+      "name": "reaction_type",
+      "schema": "public",
+      "values": [
+        "like",
+        "love",
+        "celebrate"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/lib/server/db/migrations/meta/_journal.json
+++ b/src/lib/server/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1782081005125,
       "tag": "0001_grey_black_queen",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1785073575379,
+      "tag": "0002_jittery_bastion",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/server/db/schema/users.ts
+++ b/src/lib/server/db/schema/users.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, uuid, timestamp, boolean } from 'drizzle-orm/pg-core';
+import { pgTable, text, uuid, timestamp, boolean, jsonb } from 'drizzle-orm/pg-core';
 
 export const users = pgTable('users', {
 	id: uuid('id').primaryKey().defaultRandom(),
@@ -9,6 +9,8 @@ export const users = pgTable('users', {
 	admin: boolean('admin').notNull().default(false),
 	// Set on each login (debounced to once/day). Used to exclude recently-active users from freshness polls.
 	lastSeenAt: timestamp('last_seen_at', { withTimezone: true }),
+	// Sparse map of togglable notification preferences (see src/lib/server/notifications.ts for defaults/shape).
+	notificationPreferences: jsonb('notification_preferences').notNull().default({}),
 	createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 	updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow()
 });

--- a/src/lib/server/email-templates/team-role-added.ts
+++ b/src/lib/server/email-templates/team-role-added.ts
@@ -1,0 +1,50 @@
+interface TeamRoleAddedEmailParams {
+	name: string;
+	inviterName: string;
+	teamName: string;
+	role: 'performer' | 'coach';
+	approvalsUrl: string;
+	siteUrl: string;
+}
+
+function escapeHtml(value: string): string {
+	return value
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;');
+}
+
+export function subject(params: TeamRoleAddedEmailParams): string {
+	const safeInviterName = escapeHtml(params.inviterName);
+	const safeTeamName = escapeHtml(params.teamName);
+	const roleLabel = params.role === 'coach' ? 'coach' : 'performer';
+	return `${safeInviterName} added you as a ${roleLabel} on ${safeTeamName}`;
+}
+
+export function html(params: TeamRoleAddedEmailParams): string {
+	const { name, teamName, role, inviterName, approvalsUrl, siteUrl } = params;
+	const safeName = escapeHtml(name);
+	const safeTeamName = escapeHtml(teamName);
+	const safeInviterName = escapeHtml(inviterName);
+	const roleLabel = role === 'coach' ? 'coach' : 'performer';
+
+	return `
+<div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
+  <p>Hi ${safeName},</p>
+  <p>${safeInviterName} added you as a ${roleLabel} on <strong>${safeTeamName}</strong> on Comedy Connector. It's sitting in your approvals queue — just needs a thumbs up before it shows on your profile.</p>
+  <p style="margin: 28px 0;">
+    <a href="${approvalsUrl}" style="background: #1c1c1c; color: #fff; padding: 12px 18px; text-decoration: none; font-weight: 700;">Review &amp; Approve</a>
+  </p>
+  <p>If this doesn't look right, you can reject it from the same page.</p>
+  <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 24px 0;" />
+  <p style="color: #9ca3af; font-size: 12px;">Sent via <a href="${siteUrl}" style="color: #7c3aed;">Comedy Connector</a>. You can turn these emails off anytime from your profile's Notifications settings.</p>
+</div>`;
+}
+
+export function text(params: TeamRoleAddedEmailParams): string {
+	const { name, teamName, role, inviterName, approvalsUrl } = params;
+	const roleLabel = role === 'coach' ? 'coach' : 'performer';
+	return `Hi ${name},\n\n${inviterName} added you as a ${roleLabel} on ${teamName} on Comedy Connector. It's sitting in your approvals queue — just needs a thumbs up before it shows on your profile.\n\nReview & Approve: ${approvalsUrl}\n\nIf this doesn't look right, you can reject it from the same page.\n\nSent via Comedy Connector. You can turn these emails off anytime from your profile's Notifications settings.`;
+}

--- a/src/lib/server/email.ts
+++ b/src/lib/server/email.ts
@@ -2,6 +2,7 @@ import { emailService } from '$lib/services/email';
 import * as contactTemplate from './email-templates/contact';
 import * as feedbackTemplate from './email-templates/feedback';
 import * as teamInviteTemplate from './email-templates/team-invite';
+import * as teamRoleAddedTemplate from './email-templates/team-role-added';
 
 export interface ContactEmailParams {
 	to: string;
@@ -78,6 +79,34 @@ export async function sendTeamInvite(params: TeamInviteEmailParams): Promise<voi
 	});
 
 	if (!success) throw new Error(error || 'Failed to send team invite email');
+}
+
+export interface TeamRoleAddedEmailParams {
+	to: string;
+	name: string;
+	inviterName: string;
+	teamName: string;
+	role: 'performer' | 'coach';
+	siteUrl: string;
+}
+
+export async function sendTeamRoleAddedNotification(params: TeamRoleAddedEmailParams): Promise<void> {
+	const { to, siteUrl } = params;
+	const approvalsUrl = `${siteUrl.replace(/\/$/, '')}/approvals`;
+
+	const templateParams = {
+		...params,
+		approvalsUrl
+	};
+
+	const { success, error } = await emailService.send({
+		to,
+		subject: teamRoleAddedTemplate.subject(templateParams),
+		html: teamRoleAddedTemplate.html(templateParams),
+		text: teamRoleAddedTemplate.text(templateParams)
+	});
+
+	if (!success) throw new Error(error || 'Failed to send team role added notification email');
 }
 
 // Freshness reminder emails are now sent via src/lib/server/reminders.ts

--- a/src/lib/server/notifications.ts
+++ b/src/lib/server/notifications.ts
@@ -1,0 +1,19 @@
+import type { User } from '$server/db/schema';
+
+export interface NotificationPreferences {
+	/** Email me when a team adds me as a performer (pending approval). */
+	emailOnMemberAdded: boolean;
+	/** Email me when a team adds me as a coach (pending approval). */
+	emailOnCoachAdded: boolean;
+}
+
+export const DEFAULT_NOTIFICATION_PREFERENCES: NotificationPreferences = {
+	emailOnMemberAdded: true,
+	emailOnCoachAdded: true
+};
+
+/** Merges a user's stored (possibly sparse) preferences JSON over the defaults. */
+export function getNotificationPreferences(user: Pick<User, 'notificationPreferences'>): NotificationPreferences {
+	const stored = (user.notificationPreferences ?? {}) as Partial<NotificationPreferences>;
+	return { ...DEFAULT_NOTIFICATION_PREFERENCES, ...stored };
+}

--- a/src/lib/server/profiles.ts
+++ b/src/lib/server/profiles.ts
@@ -56,6 +56,17 @@ export async function findProfileIdByEmail(email: string): Promise<string | null
 	return result[0]?.id ?? null;
 }
 
+/** Get a profile's owning user row (email, notification preferences, etc.) by profile ID. */
+export async function getUserByProfileId(profileId: string) {
+	const result = await db
+		.select({ user: users, contactEmail: personalProfiles.contactEmail, name: personalProfiles.name })
+		.from(personalProfiles)
+		.innerJoin(users, eq(personalProfiles.userId, users.id))
+		.where(eq(personalProfiles.id, profileId))
+		.limit(1);
+	return result[0] ?? null;
+}
+
 /** Get or create a profile for a user if it doesn't exist. */
 export async function ensureUserProfile(userId: string, email: string, fallbackName?: string | null): Promise<string> {
 	const existing = await getProfileByUserId(userId);

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -87,6 +87,11 @@
 			</p>
 			<span class="card-go">→</span>
 		</a>
+		<a href="/profile/notifications" class="zine-card-link">
+			<div class="card-tag">SETTINGS</div>
+			<p class="card-action-label">NOTIFICATIONS</p>
+			<span class="card-go">→</span>
+		</a>
 	</div>
 </div>
 

--- a/src/routes/profile/notifications/+page.server.ts
+++ b/src/routes/profile/notifications/+page.server.ts
@@ -1,0 +1,37 @@
+import { redirect, fail } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+import { db } from '$server/db';
+import { users } from '$server/db/schema';
+import { eq } from 'drizzle-orm';
+import { getNotificationPreferences, DEFAULT_NOTIFICATION_PREFERENCES } from '$server/notifications';
+
+export const load: PageServerLoad = async ({ locals, url }) => {
+	if (!locals.user) {
+		redirect(302, `/login?returnTo=${encodeURIComponent(url.pathname)}`);
+	}
+
+	const [user] = await db.select().from(users).where(eq(users.id, locals.user.id)).limit(1);
+	const preferences = user ? getNotificationPreferences(user) : DEFAULT_NOTIFICATION_PREFERENCES;
+	return { preferences };
+};
+
+export const actions: Actions = {
+	default: async ({ request, locals }) => {
+		if (!locals.user) {
+			return fail(401, { error: 'Not authenticated' });
+		}
+
+		const formData = await request.formData();
+		const preferences = {
+			emailOnMemberAdded: formData.get('emailOnMemberAdded') === 'true',
+			emailOnCoachAdded: formData.get('emailOnCoachAdded') === 'true'
+		};
+
+		await db
+			.update(users)
+			.set({ notificationPreferences: preferences, updatedAt: new Date() })
+			.where(eq(users.id, locals.user.id));
+
+		return { success: true, message: 'Notification preferences saved.' };
+	}
+};

--- a/src/routes/profile/notifications/+page.svelte
+++ b/src/routes/profile/notifications/+page.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import { untrack } from 'svelte';
+	import type { PageData } from './$types';
+	import { toastStore } from '$stores/toast.svelte';
+
+	let { data }: { data: PageData } = $props();
+
+	let emailOnMemberAdded = $state(untrack(() => data.preferences.emailOnMemberAdded));
+	let emailOnCoachAdded = $state(untrack(() => data.preferences.emailOnCoachAdded));
+	let saving = $state(false);
+
+	function saveEnhance() {
+		saving = true;
+		return async ({ result, update }: { result: { type: string; data?: { message?: string; error?: string } }; update: () => Promise<void> }) => {
+			if (result.type === 'success' && result.data?.message) {
+				toastStore.success(result.data.message);
+			} else if (result.type === 'failure' && result.data?.error) {
+				toastStore.error(result.data.error);
+			}
+			await update();
+			saving = false;
+		};
+	}
+</script>
+
+<svelte:head>
+	<title>Notifications | Comedy Connector</title>
+</svelte:head>
+
+<div class="form-page">
+	<h1 class="page-title">NOTIFICATIONS</h1>
+	<p class="page-sub">Choose how Comedy Connector reaches out when something needs your attention.</p>
+
+	<form method="POST" use:enhance={saveEnhance} class="zine-form">
+		<label class="checkbox-label">
+			<input type="checkbox" checked disabled />
+			<span>
+				<strong>📬 Monthly freshness check</strong>
+				<span class="field-hint">Keeps your listing accurate. Can't be turned off.</span>
+			</span>
+		</label>
+		<label class="checkbox-label">
+			<input type="checkbox" name="emailOnMemberAdded" value="true" bind:checked={emailOnMemberAdded} />
+			<span>
+				<strong>🎭 Someone adds me as a performer</strong>
+				<span class="field-hint">Email me when a team adds me and I need to approve it.</span>
+			</span>
+		</label>
+		<label class="checkbox-label">
+			<input type="checkbox" name="emailOnCoachAdded" value="true" bind:checked={emailOnCoachAdded} />
+			<span>
+				<strong>🎓 Someone adds me as a coach</strong>
+				<span class="field-hint">Email me when a team adds me and I need to approve it.</span>
+			</span>
+		</label>
+		<div class="form-actions">
+			<button type="submit" class="btn-accent" disabled={saving}>{saving ? 'SAVING…' : 'SAVE PREFERENCES'}</button>
+			<a href="/profile" class="btn-outline">CANCEL</a>
+		</div>
+	</form>
+</div>
+
+<style>
+	.form-page { max-width: 640px; margin: 0 auto; padding: 48px 32px; }
+	.page-title { font-family: var(--font-heading); font-size: 36px; color: var(--zine-primary); margin-bottom: 8px; transform: rotate(-1deg); display: inline-block; }
+	.page-sub { font-size: 14px; opacity: 0.7; margin-bottom: 32px; }
+	.zine-form { display: flex; flex-direction: column; gap: 20px; }
+	.checkbox-label { display: flex; align-items: flex-start; gap: 12px; padding: 16px; border: var(--zine-border); background: var(--zine-surface); cursor: pointer; }
+	.checkbox-label input[type='checkbox'] { margin-top: 3px; flex-shrink: 0; }
+	.checkbox-label span { display: flex; flex-direction: column; gap: 4px; }
+	.field-hint { font-size: 12px; font-weight: 400; opacity: 0.65; }
+	.form-actions { display: flex; gap: 12px; padding-top: 8px; }
+</style>

--- a/src/routes/teams/[slug]/edit/+page.server.ts
+++ b/src/routes/teams/[slug]/edit/+page.server.ts
@@ -5,8 +5,9 @@ import { db } from '$server/db';
 import { teams, teamMembers, teamCoaches, tags, entityTags, personalProfiles } from '$server/db/schema';
 import { eq, and } from 'drizzle-orm';
 import { getTeamBySlug, getTeamMembers, getOrCreateStubTeam, resolveTeamSlug } from '$server/teams';
-import { getProfileByUserId, findProfileIdByEmail } from '$server/profiles';
-import { sendTeamInvite } from '$server/email';
+import { getProfileByUserId, findProfileIdByEmail, getUserByProfileId } from '$server/profiles';
+import { sendTeamInvite, sendTeamRoleAddedNotification } from '$server/email';
+import { getNotificationPreferences } from '$server/notifications';
 import { teamSchema } from '$utils/validation';
 
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -27,6 +28,37 @@ async function sendInviteEmail(params: {
 	const siteUrl = env.PUBLIC_SITE_URL ?? 'https://pgh.comedyconnector.app';
 	await sendTeamInvite({ ...params, siteUrl });
 	return `Invitation sent to ${params.to}.`;
+}
+
+// Notifies an existing app user that they were added to a team and need to approve it.
+// Best-effort: a failure here must not block the add itself, since that action already
+// succeeded (the pending row is created either way).
+async function notifyExistingUserAdded(params: {
+	profileId: string;
+	teamName: string;
+	role: 'performer' | 'coach';
+	inviterName: string;
+}): Promise<void> {
+	try {
+		const target = await getUserByProfileId(params.profileId);
+		if (!target) return;
+
+		const prefKey = params.role === 'coach' ? 'emailOnCoachAdded' : 'emailOnMemberAdded';
+		const preferences = getNotificationPreferences(target.user);
+		if (!preferences[prefKey]) return;
+
+		const siteUrl = env.PUBLIC_SITE_URL ?? 'https://pgh.comedyconnector.app';
+		await sendTeamRoleAddedNotification({
+			to: target.contactEmail ?? target.user.email,
+			name: target.name,
+			inviterName: params.inviterName,
+			teamName: params.teamName,
+			role: params.role,
+			siteUrl
+		});
+	} catch (err) {
+		console.error('Failed to send team-role-added notification:', err);
+	}
 }
 
 export const load: PageServerLoad = async ({ params, locals, url }) => {
@@ -151,6 +183,15 @@ export const actions: Actions = {
 			approvalStatus
 		});
 
+		if (profileId) {
+			await notifyExistingUserAdded({
+				profileId,
+				teamName: team.name,
+				role: 'performer',
+				inviterName: await getInviterName(locals.user.id)
+			});
+		}
+
 		return { success: true };
 	},
 
@@ -224,6 +265,15 @@ export const actions: Actions = {
 			isCurrent,
 			approvalStatus
 		});
+
+		if (profileId) {
+			await notifyExistingUserAdded({
+				profileId,
+				teamName: team.name,
+				role: 'coach',
+				inviterName: await getInviterName(locals.user.id)
+			});
+		}
 
 		return { success: true };
 	},


### PR DESCRIPTION
## Summary

Closes #39. Adds email notifications for the one gap in the existing "added to a team" flow, plus lets users control it.

- **Existing user added as performer/coach** (`addMember`/`addCoach` picker flow) previously created a pending approval row with **no notification at all** — the user only found out by checking `/approvals`. Now they get an email ("`{inviter}` added you as a `{role}` on `{team}`") linking to their approvals page.
- The **invite-to-create-account flow** (`inviteMember`/`inviteCoach`) already emailed and is unchanged.
- New **`/profile/notifications`** settings page lets users toggle the two new emails on/off (default on). Monthly freshness check is shown but locked on, since it can't be disabled.
- Desktop/browser push notifications were considered and explicitly descoped — email only, per product decision.
- Preferences are stored as a single flexible `notification_preferences` JSONB column on `users` rather than dedicated boolean columns, to leave room for future notification types without another migration.

## Commits

- `feat(db): add notification_preferences jsonb column to users`
- `feat(email): add team-role-added notification template`
- `feat(teams): email existing users when added as performer/coach`
- `feat(profile): add notifications settings page`

## Test plan

- [x] `pnpm check` passes (0 errors, 0 warnings)
- [x] Migration generated (`0002_jittery_bastion.sql`) and applied to staging via `pnpm db:migrate`
- [x] Verified in browser via `/dev-login`:
  - Added an existing user as a performer → confirmed mock email fired with correct copy/subject/link, and the add still succeeds/toasts regardless of email outcome
  - Turned off "someone adds me as a performer" in `/profile/notifications`, confirmed the preference persists across reload
  - Re-added the same user as a performer → confirmed **no** email fired this time
  - Added a different user as a coach (separate preference, still on) → confirmed the coach-flavored email fired
  - Confirmed `/approvals` still shows the pending request regardless of email preference — this is notification-only, doesn't touch the approval flow

**Still needed before merge:** apply the generated migration to production manually via the Supabase dashboard SQL editor (per this repo's migration workflow — prod isn't touched by `db:migrate`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)