### PR TITLE
Fix OAuth flows with confirmation emails

### DIFF
--- a/src/routes/auth/callback/+server.ts
+++ b/src/routes/auth/callback/+server.ts
@@ -3,7 +3,8 @@ import type { RequestHandler } from './$types';
 
 /**
  * GET /auth/callback
- * Handles the OAuth redirect from Supabase (Google and other providers).
+ * Handles Supabase auth redirects: OAuth sign-in (Google and other providers),
+ * email confirmation links, and password-reset links.
  * Supabase sends a `code` query param which we exchange for a session.
  * The session cookies are written by the Supabase client in locals.supabase.
  */

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -10,6 +10,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 	const returnTo = url.searchParams.get('returnTo') ?? '/profile';
 	// Security: only allow relative paths
 	const safeReturnTo = returnTo.startsWith('/') ? returnTo : '/profile';
+	const authError = url.searchParams.get('error');
 
 	// Already authenticated — skip login
 	if (locals.user) redirect(302, safeReturnTo);
@@ -17,7 +18,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 	// Local dev — delegate to /dev-login (which has the test user picker).
 	if (IS_LOCAL) redirect(302, `/dev-login?returnTo=${encodeURIComponent(safeReturnTo)}`);
 
-	return { returnTo: safeReturnTo };
+	return { returnTo: safeReturnTo, error: authError };
 };
 
 export const actions: Actions = {
@@ -40,7 +41,7 @@ export const actions: Actions = {
 		redirect(302, safeReturnTo);
 	},
 
-	signup: async ({ request, locals }) => {
+	signup: async ({ request, locals, url }) => {
 		const formData = await request.formData();
 		const email = String(formData.get('email') ?? '').trim();
 		const password = String(formData.get('password') ?? '');
@@ -54,9 +55,21 @@ export const actions: Actions = {
 			return fail(400, { error: 'Password must be at least 8 characters', returnTo: safeReturnTo, mode: 'signup' });
 		}
 
-		const { error } = await locals.supabase.auth.signUp({ email, password });
+		const { data, error } = await locals.supabase.auth.signUp({
+			email,
+			password,
+			options: {
+				emailRedirectTo: `${url.origin}/auth/callback?returnTo=${encodeURIComponent(safeReturnTo)}`
+			}
+		});
 		if (error) {
 			return fail(400, { error: error.message, returnTo: safeReturnTo, mode: 'signup' });
+		}
+
+		// No session means email confirmation is required — Supabase already sent the
+		// confirmation email. Show a "check your email" state instead of redirecting.
+		if (!data.session) {
+			return { signupSent: true, mode: 'signup' as const, email };
 		}
 
 		redirect(302, safeReturnTo);

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -37,8 +37,8 @@
 			{/if}
 		</p>
 
-		{#if form?.error}
-			<p class="login-error" role="alert">{form.error}</p>
+		{#if form?.error || data.error}
+			<p class="login-error" role="alert">{form?.error ?? data.error}</p>
 		{/if}
 
 		{#if mode === 'forgot'}
@@ -71,6 +71,16 @@
 			{/if}
 			<p class="mode-toggle">
 				<button onclick={() => (mode = 'signin')} class="toggle-link">Back to sign in</button>
+			</p>
+		{:else if mode === 'signup' && form?.signupSent}
+			<!-- ── Sign up: confirmation email sent ── -->
+			<p class="success-msg" role="status">
+				Check your email — we sent a confirmation link to <strong>{form.email}</strong>. Click it
+				to finish creating your account and sign you in.
+			</p>
+			<p class="mode-toggle">
+				Already have an account?
+				<button onclick={() => (mode = 'signin')} class="toggle-link">Sign in</button>
 			</p>
 		{:else}
 			<!-- ── Sign in / Sign up ── -->


### PR DESCRIPTION
Give feedback on signup and route confirmation links through callback

Signup previously redirected silently with no session, and the confirmation email fell back to the Supabase default site URL (the marketing landing page) since emailRedirectTo was never set.

- signup action now sets emailRedirectTo to /auth/callback and shows  a "check your email" state when confirmation is required instead of  redirecting with no session
- login page surfaces /auth/callback errors via a new `error` load param
- confirmation links now exchange the code through /auth/callback, auto-logging the user into the app like the existing Google OAuth and password-reset flows